### PR TITLE
Add Ubuntu to the list of Validated Distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ gdg has been validated on:
 * Debian 10
 * RHEL7
 * RHEL8
+* Ubuntu 18.04
+* Ubuntu 20.04
 
 ## Roadmap
 


### PR DESCRIPTION
I have checked **gdg** on *Ubuntu 18.04* and *Ubuntu 20.04* and it looks alright, data is collected.

## Ubuntu 18.04
```
$ grep PRETTY /etc/os-release; sudo /usr/local/sbin/gdg --status
PRETTY_NAME="Ubuntu 18.04.5 LTS"
~~~~~~~~~~~~~~~
  gdg status
~~~~~~~~~~~~~~~
VERSION: gdg-0.9.2
STATUS: started
RTMON: stopped
INTERVAL: 30s
LOG DAYS TO KEEP: 7d
DATA LOCATION: /var/log/gdg-data/
CONFIG LOCATION: /etc/gdg.cfg
CURRENT DATA SIZE: 1MB
~~~~~~~~~~~~~~~
DSTATE: stopped
NUMPROCS: 0
```
## Ubuntu 20.04
```
$ grep PRETTY /etc/os-release; sudo /usr/local/sbin/gdg --status
PRETTY_NAME="Ubuntu 20.04.2 LTS"
~~~~~~~~~~~~~~~
  gdg status
~~~~~~~~~~~~~~~
VERSION: gdg-0.9.2
STATUS: started
RTMON: stopped
INTERVAL: 30s
LOG DAYS TO KEEP: 7d
DATA LOCATION: /var/log/gdg-data/
CONFIG LOCATION: /etc/gdg.cfg
CURRENT DATA SIZE: 15MB
~~~~~~~~~~~~~~~
DSTATE: stopped
NUMPROCS: 0
```
